### PR TITLE
fix: deploy to correct OVH path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt-get install -y lftp
 
       # Déploiement SFTP par mirroring avec mot de passe
-      - name: Mirror ./www -> /www (OVH SFTP)
+      - name: Mirror ./www -> /home/sonoprf/www (OVH SFTP)
         env:
           OVH_HOST: ${{ secrets.OVH_HOST }}       # ftp.cluster100.hosting.ovh.net
           OVH_USER: ${{ secrets.OVH_USER }}       # sonoprf
@@ -35,7 +35,7 @@ jobs:
           # - --only-newer : n'envoie que les fichiers plus récents
           # - --exclude-glob : exclut les patterns
           # - ./www : dossier local à déployer
-          # - /www  : dossier distant OVH (public)
+          # - /home/sonoprf/www : dossier distant OVH (public)
           lftp -u "$OVH_USER","$OVH_PASSWORD" sftp://$OVH_HOST -e "\
             set sftp:auto-confirm yes; \
             set net:max-retries 2; \
@@ -49,7 +49,7 @@ jobs:
               --exclude-glob *.md \
               --exclude-glob *.map \
               --exclude-glob .env* \
-              ./www /www; \
+              ./www /home/sonoprf/www; \
             bye"
 
       # (Optionnel) Healthcheck simple


### PR DESCRIPTION
## Summary
- point deploy workflow to `/home/sonoprf/www`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aee069eb808330a99b65a035e52985